### PR TITLE
add ability to set `entry` file for doc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Add yaml config (for example `docs.yml`):
 # and generate markdown to `partial/ui.md` file
 - path: partial/ui.md
   title: UI API Methods
+  # [optional] if provided, only `entry` file dependencies will be parsed
+  entry: src/index.ts
   glob: src/**/*.ts
   tag: UI
 

--- a/bin/okidoc.js
+++ b/bin/okidoc.js
@@ -49,6 +49,7 @@ Promise.all(
   docs.map(doc =>
     buildDocumentation({
       title: doc.title,
+      entry: doc.entry,
       pattern: doc.glob,
       tag: doc.tag,
       visitor: doc.visitor,

--- a/package.json
+++ b/package.json
@@ -48,9 +48,12 @@
     "cross-spawn": "^6.0.4",
     "documentation": "^5.3.5",
     "ejs": "^2.5.7",
+    "filing-cabinet": "^1.13.1",
     "glob": "^7.1.2",
     "lodash": "^4.17.5",
+    "minimatch": "^3.0.4",
     "ncp": "^2.0.0",
+    "precinct": "^4.0.0",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/src/buildDocumentation.js
+++ b/src/buildDocumentation.js
@@ -4,9 +4,9 @@ import documentation from 'documentation';
 import buildDocumentationAst from './buildDocumentationAst';
 import { buildMarkdown } from './output';
 
-function buildDocumentation({ title, pattern, tag, visitor }) {
+function buildDocumentation({ title, entry, pattern, tag, visitor }) {
   const { code: documentationSource } = generate(
-    buildDocumentationAst(pattern, { tag, visitor }),
+    buildDocumentationAst({ entry, pattern, tag, visitor }),
   );
 
   return documentation

--- a/src/utils/glob.js
+++ b/src/utils/glob.js
@@ -1,7 +1,17 @@
+import path from 'path';
 import _glob from 'glob';
+import minimatch from 'minimatch';
+
+function isMatchGlob(filePath, pattern) {
+  const relativeFilePath = path.relative(process.cwd(), filePath);
+
+  return minimatch(relativeFilePath, pattern, { dot: false });
+}
 
 function glob(pattern) {
   return _glob.sync(pattern, { nodir: true, dot: false });
 }
+
+export { isMatchGlob };
 
 export default glob;

--- a/src/utils/traverseEntries.js
+++ b/src/utils/traverseEntries.js
@@ -1,0 +1,85 @@
+import path from 'path';
+import precinct from 'precinct';
+import cabinet from 'filing-cabinet';
+import traverse from '@babel/traverse';
+
+import parseFile from './parseFile';
+import { isMatchGlob } from './glob';
+
+const EXCLUDE_PATTERN = /\.(css|sass|scss|svg|png|jpg|dot|graphql)$/;
+
+function resolveDependencyPath({ dependency, entryPath, entryAST }) {
+  const config = {
+    filename: entryPath,
+    directory: process.cwd(),
+    ast: entryAST,
+  };
+
+  return (
+    cabinet({ ...config, partial: dependency }) ||
+    cabinet({ ...config, partial: dependency + '/index' })
+  );
+}
+
+function traverseEntry(entryPath, visitors, { pattern, visited = [] } = {}) {
+  const entryAST = parseFile(entryPath);
+
+  visited.push(entryPath);
+
+  precinct(entryAST, { type: 'es6', es6: { mixedImports: true } }).forEach(
+    dependency => {
+      // NOTE: only internal dependencies
+      // TODO: allow path alias aka webpack alias https://webpack.js.org/configuration/resolve/#resolve-alias
+      // https://github.com/dependents/node-filing-cabinet#usage
+      if (!dependency.startsWith('.')) {
+        return;
+      }
+
+      const dependencyPath = resolveDependencyPath({
+        dependency,
+        entryPath,
+        entryAST,
+      });
+
+      if (!dependencyPath) {
+        // NOTE: don't warn if dependency is not `js` or `ts`
+        if (!EXCLUDE_PATTERN.test(dependency)) {
+          console.warn(
+            `could not find '${dependency}' or '${dependency +
+              '/index'}' dependency for '${entryPath}'`,
+          );
+        }
+        return;
+      }
+
+      // NOTE: prevent circular traverse
+      if (
+        visited.includes(dependencyPath) ||
+        (pattern && !isMatchGlob(dependencyPath, pattern))
+      ) {
+        return;
+      }
+
+      traverseEntry(dependencyPath, visitors, { pattern, visited });
+    },
+  );
+
+  // TODO: ensure declarations are exported before add to doc
+  traverse(entryAST, visitors);
+}
+
+function traverseEntries(entry, visitors, { pattern }) {
+  const entries = Array.isArray(entry) ? entry : [entry];
+
+  if (entries.some(_entry => typeof _entry !== 'string')) {
+    throw new Error(`'entry' prop should be 'string' or array of 'string'`);
+  }
+
+  entries.forEach(entry => {
+    traverseEntry(path.resolve(entry), visitors, {
+      pattern: pattern,
+    });
+  });
+}
+
+export default traverseEntries;

--- a/src/utils/traverseFiles.js
+++ b/src/utils/traverseFiles.js
@@ -1,7 +1,15 @@
 import traverse from '@babel/traverse';
 import parseFile from './parseFile';
+import glob from './glob';
 
-function traverseFiles(files, visitor) {
+function traverseFiles(pattern, visitor) {
+  const files = glob(pattern);
+
+  if (files.length === 0) {
+    console.warn(`files not found for ${pattern} pattern`);
+    return;
+  }
+
   files.forEach(filePath => {
     traverse(parseFile(filePath), visitor);
   });


### PR DESCRIPTION
example:
```yaml
- path: player-public-methods.md
  title: Player public methods
  entry: src/default-modules/index.ts
  glob: src/**/*.ts
  visitor: scripts/documentation/playerApiVisitor.js
```