### PR TITLE
[okidoc-md] fix rendering optional/nullable/rest types

### DIFF
--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -142,7 +142,7 @@ myMethod comment
       <tr>
         <td class=\\"param\\">
           <code>b</code>
-          <div class=\\"type\\">number</div>
+          <div class=\\"type\\">number?</div>
         </td>
         <td>
             <p><code>b</code> description</p>
@@ -266,6 +266,110 @@ myMethod comment
         </td>
         <td>
             <p>returns comment</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown for API class should render markdown for methods with \`...rest\` as param 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myMethod()
+
+myMethod comment
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>ARGUMENTS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>arr</code>
+          <div class=\\"type\\">...Array&#x3C;string></div>
+        </td>
+        <td>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <div class=\\"type\\">Array&#x3C;string></div>
+        </td>
+        <td>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown for API class should render markdown for methods with \`optional\` as param 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myMethod()
+
+myMethod comment
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>ARGUMENTS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>x</code>
+          <div class=\\"type\\">number?</div>
+        </td>
+        <td>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <div class=\\"type\\">number</div>
+        </td>
+        <td>
         </td>
       </tr>
     </tbody>

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -117,6 +117,40 @@ describe('buildMarkdown', () => {
       expect(markdown).toMatchSnapshot();
     });
 
+    it('should render markdown for methods with `...rest` as param', async () => {
+      const documentationSource = `
+      /** Example class jsdoc */
+      class API {
+        /**
+        * myMethod comment
+        */
+        myMethod(...arr: string[]): string[] {
+          return arr;
+        }
+      }
+    `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it.only('should render markdown for methods with `optional` as param', async () => {
+      const documentationSource = `
+      /** Example class jsdoc */
+      class API {
+        /**
+        * myMethod comment
+        */
+        myMethod(x: ?number): number {
+          return number;
+        }
+      }
+    `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+
     it('should render markdown for methods interface as return type', async () => {
       const documentationSource = `
      /**
@@ -126,7 +160,7 @@ describe('buildMarkdown', () => {
       */
       interface MyResult {
         a: string;
-        b: number;
+        b?: number;
       }
 
       /** Example class jsdoc */

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/formatType.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/formatType.js
@@ -109,18 +109,22 @@ function formatType(node) {
     case Syntax.RestType:
       // note that here we diverge from doctrine itself, which
       // lets the expression be omitted.
-      return [t('...'), formatType(node.expression)];
+      return [t('...'), ...formatType(node.expression)];
     case Syntax.OptionalType:
       if (node.default) {
-        return [formatType(node.expression), t('?'), t('= ' + c(node.default))];
+        return [
+          ...formatType(node.expression),
+          t('?'),
+          t('= ' + c(node.default)),
+        ];
       }
-      return [formatType(node.expression), t('?')];
+      return [...formatType(node.expression), t('?')];
     case Syntax.NonNullableType:
       return node.prefix
-        ? [t('?'), formatType(node.expression)]
-        : [formatType(node.expression), t('?')];
+        ? [t('?'), ...formatType(node.expression)]
+        : [...formatType(node.expression), t('?')];
     case Syntax.NullableType:
-      return [formatType(node.expression), t('?')];
+      return [...formatType(node.expression), t('?')];
     case Syntax.StringLiteralType:
       return [c(JSON.stringify(node.value))];
     case Syntax.NumericLiteralType:


### PR DESCRIPTION
Fixed bug with nullable type in interfaces property.
Add tests for optional/rest types.

Due to the difference in [optional notation flow vs typescript](https://github.com/niieani/typescript-vs-flowtype#maybe--nullable-type), `documentationjs` renders only `x: ?number` notation as optional. `x?: number` will be rendered as a regular param.

For interface properties, `x: ?number` and `x?: number` rendered as optional.