### PR TITLE
update `@example` and `@note` rendering

### DIFF
--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -161,7 +161,9 @@ exports[`buildMarkdown for API class should render markdown for methods with @ex
 
 ## myMethod()
 
-_test example caption_
+> \`myMethod\` note 1
+
+> test example caption
 
 \`\`\`javascript
 console.log('example')
@@ -171,7 +173,7 @@ console.log('example')
 console.log('example')
 \`\`\`
 
-> \`myMethod\` note 
+> \`myMethod\` note 2
 > Read more about [myMethod](/my-method)
 
 myMethod comment
@@ -438,7 +440,7 @@ exports[`buildMarkdown for API class should render markdown sections in valid or
 
 ## myMethod1()
 
-_test example caption_
+> test example caption
 
 \`\`\`javascript
 console.log('example')
@@ -597,7 +599,7 @@ myFunc1 description
 
 ## myFunc2()
 
-_MyFunc example_
+> MyFunc example
 
 \`\`\`javascript
 console.log(myFunc(3, 2))

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -96,6 +96,9 @@ describe('buildMarkdown', () => {
         * myMethod comment
         * @param x - \`x\` description. see http://example.com
         * 
+        * @note
+        * \`myMethod\` note 1
+        *
         * @example <caption>test example caption</caption>
         * console.log('example')
         *
@@ -103,7 +106,7 @@ describe('buildMarkdown', () => {
         * console.log('example')
         *
         * @note
-        * \`myMethod\` note 
+        * \`myMethod\` note 2
         * Read more about [myMethod](/my-method)
         *
         */

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/renderComment.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/renderComment.js
@@ -42,32 +42,30 @@ function renderParams(comment) {
   );
 }
 
-function renderExamples(comment) {
+function renderExamplesAndNotes(comment) {
   return (
-    comment.examples.length > 0 &&
-    comment.examples.reduce(
-      (memo, example) =>
-        memo
-          .concat(
-            example.caption
-              ? [u('paragraph', [u('emphasis', example.caption)])]
-              : [],
-          )
-          .concat([u('code', { lang: 'javascript' }, example.description)]),
-      [],
-    )
-  );
-}
+    comment.tags.length > 0 &&
+    comment.tags.reduce((memo, tag) => {
+      if (tag.title === 'example') {
+        const exampleCaption = tag.caption;
+        const exampleCode = tag.description;
 
-function renderNotes(comment) {
-  const notes = comment.tags.filter(tag => tag.title === 'note');
-  return (
-    notes.length &&
-    notes.reduce(
-      (memo, note) =>
-        memo.concat([u('blockquote', parseMarkdown(note.description))]),
-      [],
-    )
+        return memo.concat(
+          exampleCaption
+            ? [
+                u('blockquote', parseMarkdown(exampleCaption)),
+                u('code', { lang: 'javascript' }, exampleCode),
+              ]
+            : [u('code', { lang: 'javascript' }, exampleCode)],
+        );
+      }
+
+      if (tag.title === 'note') {
+        return memo.concat([u('blockquote', parseMarkdown(tag.description))]);
+      }
+
+      return memo;
+    }, [])
   );
 }
 
@@ -104,8 +102,7 @@ function renderComment(comment, { depth, interfaces }) {
 
   if (['function', 'member'].includes(comment.kind)) {
     return renderHeading(comment, depth)
-      .concat(renderExamples(comment))
-      .concat(renderNotes(comment))
+      .concat(renderExamplesAndNotes(comment))
       .concat(comment.description ? comment.description.children : [])
       .concat(renderSeeLink(comment))
       .concat(renderParams(comment))


### PR DESCRIPTION
- render `example` and `note` in order like in jsdoc
- render `example` caption with `blockquote` tag instead of emphasis paragraph