### PR TITLE
[okidoc-md] log md file after rendering + refactore okidoc-md bin

### DIFF
--- a/packages/okidoc-md/src/utils/writeFile.js
+++ b/packages/okidoc-md/src/utils/writeFile.js
@@ -1,5 +1,8 @@
 import fs from 'fs';
 import path from 'path';
+import util from 'util';
+
+const _writeFile = util.promisify(fs.writeFile);
 
 function createFileDirectoryIfNotExists(filePath) {
   const fileDirectory = path.dirname(filePath);
@@ -12,4 +15,10 @@ function createFileDirectoryIfNotExists(filePath) {
   fs.mkdirSync(fileDirectory);
 }
 
-export default createFileDirectoryIfNotExists;
+function writeFile(filePath, fileData) {
+  createFileDirectoryIfNotExists(filePath);
+
+  return _writeFile(filePath, fileData);
+}
+
+export default writeFile;


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/2445828/38204019-de30ed02-36a9-11e8-8075-0da53df524d9.png)
