### PR TITLE
ensure TS source code is compatible with flow (used in documentation.js)

### DIFF
--- a/packages/okidoc-md/src/__snapshots__/buildDocumentation.spec.js.snap
+++ b/packages/okidoc-md/src/__snapshots__/buildDocumentation.spec.js.snap
@@ -35,11 +35,11 @@ exports[`buildDocumentation should build documentation for functions  1`] = `
 `;
 
 exports[`buildDocumentation should show readable error from \`documentation.js\` 1`] = `
-[SyntaxError: documentation source: Unexpected token (4:9)
-  2 | class API {
-  3 |   /** */
-> 4 |   public show() {}
-    |         ^
-  5 | 
-  6 | }]
+[SyntaxError: documentation source: Unexpected token, expected , (6:19)
+  4 | /**
+  5 | */
+> 6 | function fooGood<T extends {
+    |                   ^
+  7 |   x: number;
+  8 | }>(obj: T): T {}]
 `;

--- a/packages/okidoc-md/src/api/createApiInterface.js
+++ b/packages/okidoc-md/src/api/createApiInterface.js
@@ -1,8 +1,19 @@
+import * as t from '@babel/types';
 import { createJSDocCommentBlock } from '../utils/JSDocAST';
 
-function createApiInterface(node) {
+function createApiInterface(node, path) {
   // NOTE: add empty JSDoc to force `documentation.js` to add this class to documentation
   node.leadingComments = node.leadingComments || [createJSDocCommentBlock('')];
+
+  // NOTE: ensure TS code is compatible with documentation.js (babel 7 flow preset)
+  path.traverse({
+    TSMethodSignature(path) {
+      // convert code like `show();` to `show(): void;`
+      if (!path.node.typeAnnotation) {
+        path.node.typeAnnotation = t.tsTypeAnnotation(t.tsVoidKeyword());
+      }
+    },
+  });
 
   return node;
 }

--- a/packages/okidoc-md/src/api/createApiMethod.js
+++ b/packages/okidoc-md/src/api/createApiMethod.js
@@ -15,6 +15,11 @@ function createApiMethod(
     node.key = t.identifier(identifierName);
   }
 
+  // NOTE: ensure TS code is compatible with documentation.js (babel 7 flow preset)
+  if (node.accessibility) {
+    node.accessibility = null;
+  }
+
   cleanUpNodeJSDoc(node, JSDocComment, { docTag });
   removeNodeDecorators(node);
   removeNodeBody(node);

--- a/packages/okidoc-md/src/buildDocumentation.spec.js
+++ b/packages/okidoc-md/src/buildDocumentation.spec.js
@@ -83,13 +83,12 @@ describe('buildDocumentation', () => {
   });
 
   it('should show readable error from `documentation.js`', async () => {
+    // NOTE: https://github.com/niieani/typescript-vs-flowtype#bounded-polymorphism
     const sourceCode = `
       /**
       * @doc UI
       */
-      class UI {
-        public show() {}
-      }
+      function fooGood<T extends { x: number }>(obj: T): T {}
     `;
 
     expect.assertions(1);

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/__snapshots__/buildDocumentationSource.spec.js.snap
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/__snapshots__/buildDocumentationSource.spec.js.snap
@@ -139,6 +139,25 @@ exports[`buildDocumentationSource by source glob pattern should show readable er
   3 | export { Component };"
 `;
 
+exports[`buildDocumentationSource for API class should cleanup typescript vs flow difference class public method 1`] = `
+"/** */
+class API {
+  /** */
+  show() {}
+
+}"
+`;
+
+exports[`buildDocumentationSource for API class should cleanup typescript vs flow difference interface void method 1`] = `
+"/** */
+interface IView {
+  show(): void;
+}
+
+/** */
+class API {}"
+`;
+
 exports[`buildDocumentationSource for API class with @doc tag on class declaration should extract class members 1`] = `
 "/** */
 class API {

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/buildDocumentationSource.spec.js
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/buildDocumentationSource.spec.js
@@ -225,6 +225,41 @@ describe('buildDocumentationSource', () => {
         ).toMatchSnapshot();
       });
     });
+
+    describe('should cleanup typescript vs flow difference', () => {
+      it('interface void method', () => {
+        const sourceCode = `
+        interface IView {
+          show();
+        }
+      `;
+
+        expect(
+          buildDocumentationSource({
+            source: sourceCode,
+            tag: 'UI',
+          }),
+        ).toMatchSnapshot();
+      });
+
+      it('class public method', () => {
+        const sourceCode = `
+        /**
+        * @doc UI
+        */
+        class View {
+          public show() {}
+        }
+      `;
+
+        expect(
+          buildDocumentationSource({
+            source: sourceCode,
+            tag: 'UI',
+          }),
+        ).toMatchSnapshot();
+      });
+    });
   });
 
   describe('for functions', () => {

--- a/packages/okidoc-md/src/buildDocumentationSource/buildDocumentationSourceAST.js
+++ b/packages/okidoc-md/src/buildDocumentationSource/buildDocumentationSourceAST.js
@@ -99,7 +99,7 @@ function buildDocumentationSourceAST({
   // https://github.com/babel/babel/blob/master/packages/babel-traverse/src/visitors.js
   const visitors = {
     'InterfaceDeclaration|TSInterfaceDeclaration': path => {
-      apiInterfaces.push(createApiInterface(path.node));
+      apiInterfaces.push(createApiInterface(path.node, path));
     },
   };
 


### PR DESCRIPTION
ensure TS code is compatible with documentation.js (babel 7 flow preset):
- [void interface method type](https://astexplorer.net/#/gist/b81ef7c4668b5fbd02fa99d36ba66e8e/0390242f3bb587e1fd51d49098366d8e360cffd1)
- [class method with accessor (public/private/...)](https://astexplorer.net/#/gist/b81ef7c4668b5fbd02fa99d36ba66e8e/4fec2219b90ee300c98afe1547486aa2c60a38ae)