### PR TITLE
[WIP] Render interface properties from `Promise` and `Array` return types

### DIFF
--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -864,3 +864,139 @@ create new entity
 </div>
 "
 `;
+
+exports[`buildMarkdown with ApplicationType as return type should render markdown for methods with Array & interface as @returns type 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myFn()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th><div class=\\"type\\">Array&#x3C;IResult></div></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>x</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+      <tr>
+        <td class=\\"param\\">
+          <code>y</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown with ApplicationType as return type should render markdown for methods with Array as @returns type 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myFn()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+        </td>
+        <td>
+            <div class=\\"type\\">Array&#x3C;string></div>
+            <p>returns comment</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown with ApplicationType as return type should render markdown for methods with Promise & interface as @returns type 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myFn()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th><div class=\\"type\\">Promise&#x3C;IResult></div></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>x</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+      <tr>
+        <td class=\\"param\\">
+          <code>y</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown with ApplicationType as return type should render markdown for methods with Promise as @returns type 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## myFn()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th>RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+        </td>
+        <td>
+            <div class=\\"type\\">Promise&#x3C;string></div>
+            <p>returns comment</p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -346,4 +346,74 @@ describe('buildMarkdown', () => {
       expect(markdown).toMatchSnapshot();
     });
   });
+
+  describe('with ApplicationType as return type', () => {
+    it('should render markdown for methods with Promise as @returns type', async () => {
+      const documentationSource = `
+      /**
+      * @returns returns comment
+      */
+      function myFn(): Promise<string> {
+        return x;
+      }
+      `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it('should render markdown for methods with Promise & interface as @returns type', async () => {
+      const documentationSource = `
+      /** */
+      interface IResult {
+        x: number;
+        y: number;
+      }
+
+      /**
+      * @returns returns comment
+      */
+      function myFn(): Promise<IResult> {
+        return {x: 1, y: 1};
+      }
+      `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it('should render markdown for methods with Array as @returns type', async () => {
+      const documentationSource = `
+      /**
+      * @returns returns comment
+      */
+      function myFn(): string[] {
+        return [''];
+      }
+      `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it('should render markdown for methods with Array & interface as @returns type', async () => {
+      const documentationSource = `
+      /** */
+      interface IResult {
+        x: number;
+        y: number;
+      }
+
+      /**
+      * @returns returns comment
+      */
+      function myFn(): IResult[] {
+        return [{x: 1, y: 1}];
+      }
+      `;
+      const markdown = await getMarkdown(documentationSource, 'API Methods');
+
+      expect(markdown).toMatchSnapshot();
+    });
+  });
 });

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseMarkdown.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseMarkdown.js
@@ -1,0 +1,7 @@
+import remark from 'remark';
+
+function parseMarkdown(markdown) {
+  return remark().parse(markdown);
+}
+
+export default parseMarkdown;

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
@@ -1,0 +1,64 @@
+import { Syntax } from './formatType';
+import parseMarkdown from './parseMarkdown';
+
+function isPromiseType(type) {
+  return type.type === Syntax.NameExpression && type.name === 'Promise';
+}
+
+function isArrayType(type) {
+  return type.type === Syntax.NameExpression && type.name === 'Array';
+}
+
+function getInterfaceByType(type, interfaces) {
+  if (type.type === Syntax.NameExpression) {
+    return interfaces.find(
+      _interface =>
+        _interface.name === type.name && _interface.properties.length > 0,
+    );
+  }
+}
+
+function getParamsFromInterface(_interface) {
+  return _interface.properties.map(property => {
+    const tag = _interface.tags.find(
+      tag => tag.title === 'property' && tag.name === property.name,
+    );
+
+    return {
+      ...property,
+      description: tag && parseMarkdown(tag.description),
+    };
+  });
+}
+
+function parseReturnsComment(returns, interfaces) {
+  const returnsType = returns.type;
+
+  if (
+    returnsType.type === Syntax.TypeApplication &&
+    (isPromiseType(returnsType.expression) ||
+      isArrayType(returnsType.expression))
+  ) {
+    const returnsInterface = getInterfaceByType(
+      returnsType.applications[0],
+      interfaces,
+    );
+
+    if (returnsInterface) {
+      return {
+        applicationType: returns.type,
+        params: getParamsFromInterface(returnsInterface),
+      };
+    }
+  }
+
+  const returnsInterface = getInterfaceByType(returnsType, interfaces);
+
+  return {
+    params: returnsInterface
+      ? getParamsFromInterface(returnsInterface)
+      : [returns],
+  };
+}
+
+export default parseReturnsComment;

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/renderParamsHTML.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/renderParamsHTML.js
@@ -5,7 +5,7 @@ import {
 } from './renderHTML';
 import formatType, { Syntax, commaList } from './formatType';
 
-function renderParamsHTML(params, title) {
+function renderParamsHTML(params, { title, applicationType }) {
   function hasDefault(param) {
     return !!param.default;
   }
@@ -38,8 +38,8 @@ function renderParamsHTML(params, title) {
     );
   }
 
-  function renderParamType(param) {
-    return renderInlineHTML(formatType(param.type));
+  function renderType(type) {
+    return renderInlineHTML(formatType(type));
   }
 
   return cleanUpMultilineHTML(`
@@ -48,7 +48,11 @@ function renderParamsHTML(params, title) {
     <thead>
       <tr>
         <th>${title}</th>
-        <th></th>
+        <th>${
+          applicationType
+            ? `<div class="type">${renderType(applicationType)}</div>`
+            : ''
+        }</th>
       </tr>
     </thead>
     <tbody>
@@ -64,8 +68,8 @@ function renderParamsHTML(params, title) {
             ${
               !isUnionWithLiterals(param)
                 ? hasType(param, Syntax.FunctionType)
-                  ? `<code>${renderParamType(param)}</code>`
-                  : `<div class="type">${renderParamType(param)}</div>`
+                  ? `<code>${renderType(param.type)}</code>`
+                  : `<div class="type">${renderType(param.type)}</div>`
                 : ''
             }
             ${


### PR DESCRIPTION
Resolve & render interfaces inside ApplicationType like `Promise` and `Array`
Example:
```
interface IMediaSource {
  url: string;
  type: string;
}

/**
* @returns this comment not rendered
*/
function fn(): Promise<IMediaSource> {
  // ...
}
```
![image](https://user-images.githubusercontent.com/2445828/38562521-73c03b72-3ce3-11e8-80d6-6428ce6d8ca1.png)

TODO:

- [ ] Decide where to render `@returns` comment? Or skip comment render?
