### PR TITLE
feat(okidoc-md): allow to use `okidoc-md` without params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ class MySuperUIEvents {
 }
 ```
 
-Add yaml config (for example `docs.yml`):
+Add yaml config (default config path is `docs.yml`):
 
 ```yaml
 # Get files using `entry` or/and `glob` (could be `.js` or `.ts` files),
@@ -94,9 +94,13 @@ Add yaml config (for example `docs.yml`):
 Run `okidoc-md` script
 
 ```sh
-# generate markdown docs using configuration from `./docs.yml` and put them to `./docs` directory
 okidoc-md ./docs.yml ./docs
 ```
+
+It will generates docs markdown using configuration from `./docs.yml` and put them to `./docs` directory
+
+> NOTE: `./docs.yml` and `./docs` are default values for `configPath` and `outputDir` arguments and can be omitted.
+> Run `okidoc-md --help` for help.
 
 ## Customize documentation generation
 

--- a/packages/okidoc-md/bin/okidoc-md.js
+++ b/packages/okidoc-md/bin/okidoc-md.js
@@ -1,73 +1,23 @@
 #!/usr/bin/env node
 
-const yaml = require('yamljs');
-const fs = require('fs');
-const path = require('path');
-const { buildDocumentation } = require('../lib');
+const program = require('caporal');
 
-const writeFile = require('../lib/utils/writeFile').default;
-const { colorFgGreen, colorFgCyan } = require('../lib/utils/consoleUtils');
+const pkg = require('../package.json');
 
-// NOTE: ignore first 2 arguments (node and path of this file)
-const [docsYamlPath, outputDir] = process.argv.slice(2);
+const runCLI = require('../lib/cli').default;
 
-const RUN_EXAMPLE = `
-  run example:
-    '> okidoc ./docs.yml ./docs'
-`;
+program
+  .version(pkg.version)
+  .description('okidoc-md')
+  .argument('[configPath]', 'Config file path', program.STRING, './docs.yml')
+  .argument('[outputDir]', 'Markdown output dir', program.STRING, './docs')
+  .option('-c --config <configPath>', 'Config file path', program.STRING)
+  .option('-o --output <outputDir>', 'Markdown output base dir', program.STRING)
+  .action((args, options) => {
+    runCLI({
+      configPath: options.config || args.configPath,
+      outputDir: options.output || args.outputDir,
+    });
+  });
 
-if (!docsYamlPath || !fs.existsSync(docsYamlPath)) {
-  throw new Error(
-    `docs yaml path should be valid path.
-    '${docsYamlPath || ''}' is not exists.
-    ${RUN_EXAMPLE}`,
-  );
-}
-
-if (!outputDir) {
-  throw new Error(
-    `docs target path not provided.
-    ${RUN_EXAMPLE}`,
-  );
-}
-
-let docs;
-
-try {
-  docs = yaml.load(docsYamlPath);
-} catch (e) {
-  console.error(e);
-  throw new Error(
-    `invalid docs yaml file. An error occurred while parsing ${docsYamlPath}.`,
-  );
-}
-
-Promise.all(
-  docs.map(doc => {
-    const start = Date.now();
-    const markdownPath = path.join(
-      outputDir,
-      doc.path.endsWith('.md') ? doc.path : doc.path + '.md',
-    );
-
-    console.log(`${colorFgGreen('starting')} ${markdownPath}`);
-
-    return buildDocumentation({
-      title: doc.title,
-      entry: doc.entry,
-      pattern: doc.glob,
-      tag: doc.tag,
-      visitor: doc.visitor,
-    })
-      .then(markdown => writeFile(markdownPath, markdown))
-      .then(() => {
-        console.log(
-          `${colorFgCyan('finished')} ${markdownPath} ${Date.now() - start}ms`,
-        );
-      });
-  }),
-).catch(err => {
-  console.error('An error occurred while building documentation', err);
-
-  process.exit(1);
-});
+program.parse(process.argv);

--- a/packages/okidoc-md/package.json
+++ b/packages/okidoc-md/package.json
@@ -28,6 +28,7 @@
     "@babel/traverse": "7.0.0-beta.40",
     "@babel/types": "7.0.0-beta.40",
     "babylon": "7.0.0-beta.40",
+    "caporal": "^0.10.0",
     "doctrine-temporary-fork": "2.0.1",
     "documentation": "^6.2.0",
     "ejs": "^2.5.7",

--- a/packages/okidoc-md/src/cli.js
+++ b/packages/okidoc-md/src/cli.js
@@ -1,0 +1,69 @@
+import path from 'path';
+import buildDocumentation from './buildDocumentation';
+
+import writeFile from './utils/writeFile';
+import { colorFgGreen, colorFgCyan } from './utils/consoleUtils';
+import yaml from 'yamljs';
+
+function loadConfig(configPath) {
+  return new Promise((resolve, reject) => {
+    try {
+      const docs = yaml.load(configPath);
+      resolve(docs);
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+function runBuildDocumentation(docs, { outputDir }) {
+  if (!Array.isArray(docs) || docs.length === 0) {
+    return Promise.reject(new Error(`Config is empty or has invalid format.`));
+  }
+
+  return Promise.all(
+    docs.map(doc => {
+      const start = Date.now();
+      const markdownPath = path.join(
+        outputDir,
+        doc.path.endsWith('.md') ? doc.path : doc.path + '.md',
+      );
+
+      console.log(`${colorFgGreen('starting')} ${markdownPath}`);
+
+      return buildDocumentation({
+        title: doc.title,
+        entry: doc.entry,
+        pattern: doc.glob,
+        tag: doc.tag,
+        visitor: doc.visitor,
+      })
+        .then(markdown => writeFile(markdownPath, markdown))
+        .then(() => {
+          console.log(
+            `${colorFgCyan('finished')} ${markdownPath} ${Date.now() -
+              start}ms`,
+          );
+        });
+    }),
+  );
+}
+
+function runCLI({ configPath, outputDir }) {
+  loadConfig(configPath)
+    .then(
+      docs => runBuildDocumentation(docs, { outputDir }),
+      error => {
+        console.error(
+          `Could not load config '${configPath}': ${error.message}`,
+        );
+        process.exit(1);
+      },
+    )
+    .catch(error => {
+      console.error('An error occurred while building documentation.', error);
+      process.exit(1);
+    });
+}
+
+export default runCLI;


### PR DESCRIPTION
Use caporal for better use experience with lib CLI.
`configPath` and `outputPath` params now optional and has default values `./docs.yml` and `./docs`.