### PR TITLE
feat(okidoc-site): render react components inside markdown

### DIFF
--- a/docs/okidoc-site-md-components.md
+++ b/docs/okidoc-site-md-components.md
@@ -1,0 +1,65 @@
+---
+title: "React components inside markdown"
+layout: simple
+---
+
+# React components inside markdown
+
+To use react components inside markdown, create components map and `mdComponents` prop inside `./site.yml`:
+
+```yaml
+# ./site.yml
+...
+mdComponents:
+  # path to react components map
+  path: ./docs/playground-components.js
+
+  # [optional] links to external styles. Will be added to html head.
+  externalStyles:
+    - https://example.com/component@1.10.2/dist/component.css
+
+  # [optionsl] links to external scripts. Will be added to end of html body.
+  externalScripts:
+    - https://example.com/component@1.10.2/dist/component.bundle.min.js
+...
+```
+
+> `path` should be valid path to `js` file which could be handled by default [gatsby](https://www.gatsbyjs.org/) config.
+
+```js
+// ./docs/playground-components.js
+
+import React from 'react';
+
+function Demo1() {
+  return <span>!DEMO1!</span>;
+}
+
+function Demo2() {
+  return <span>!DEMO2!</span>;
+}
+
+export default {
+  demo1: Demo1,
+  demo2: Demo2,
+};
+```
+
+> NOTE: You could use [css modules](https://www.gatsbyjs.org/tutorial/part-two/#css-modules) and [sass](https://www.gatsbyjs.org/packages/gatsby-plugin-sass/) with your react components inside md.
+
+Then use components in any `md` file:
+
+```md
+<!-- index.md -->
+
+# Demo
+
+<demo1></demo1>
+
+<demo2></demo2>
+```
+
+> NOTE:
+> md components logic is inspired by [rehype-react](https://using-remark.gatsbyjs.org/custom-components/),
+> and based on [hast-to-hyperscript](https://github.com/syntax-tree/hast-to-hyperscript),
+> so has the same caveats.

--- a/docs/partial/okidoc-site.md
+++ b/docs/partial/okidoc-site.md
@@ -45,6 +45,10 @@ config:
  # [optional] Link to your github repository
  githubLink: YOUR_GITHUB_REPOSITORY
 
+# [optional] react components inside markdown
+mdComponents:
+  path: ./docs/playground-components.js
+
 # [optional] navigation config. Use if you need more than one page in navigation block
 navigation:
  - path: /config
@@ -53,7 +57,10 @@ navigation:
    title: Methods
 ```
 
-Read more about cross-page navigation [here](/okidoc-site-navigation)
+Read more:
+
+* [react components inside markdown](/okidoc-site-md-components)
+* [navigation config](/okidoc-site-navigation)
 
 Run `okidoc-site` script
 

--- a/packages/okidoc-site/site/gatsby-config.js
+++ b/packages/okidoc-site/site/gatsby-config.js
@@ -1,5 +1,9 @@
 const site = require('./getSiteConfig');
 
+if (site.mdComponents) {
+  process.env.GATSBY_MD_COMPONENTS_PATH = site.mdComponents.path;
+}
+
 if (site.config.algoliaApiKey) {
   process.env.GATSBY_ALGOLIA_API_KEY = site.config.algoliaApiKey;
 }
@@ -61,5 +65,13 @@ module.exports = {
         ],
       },
     },
+    ...(site.mdComponents
+      ? [
+          {
+            resolve: 'gatsby-md-components',
+            options: site.mdComponents,
+          },
+        ]
+      : []),
   ],
 };

--- a/packages/okidoc-site/site/gatsby-node.js
+++ b/packages/okidoc-site/site/gatsby-node.js
@@ -66,11 +66,9 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
   });
 };
 
-// TODO: cleanup when issue resolved https://github.com/gatsbyjs/gatsby/issues/2792#issuecomment-361944910
+// TODO: review when issue resolved https://github.com/gatsbyjs/gatsby/issues/2792#issuecomment-361944910
 exports.modifyWebpackConfig = ({ config }) => {
-  config._loaders.js.config.include = [
-    new RegExp(process.cwd() + '/src'),
-    new RegExp(process.cwd() + '/.cache'),
-  ];
-  config._loaders.js.config.exclude = undefined;
+  config._loaders.js.config.exclude = new RegExp(
+    process.cwd() + '/node_modules/',
+  );
 };

--- a/packages/okidoc-site/site/getSiteConfig.js
+++ b/packages/okidoc-site/site/getSiteConfig.js
@@ -22,6 +22,11 @@ const configSchema = {
     algoliaIndexName: Joi.string(),
     githubLink: Joi.string(),
   }),
+  mdComponents: Joi.object({
+    path: Joi.string().required(),
+    externalStyles: Joi.array().items(Joi.string()),
+    externalScripts: Joi.array().items(Joi.string()),
+  }),
   navigation: Joi.alternatives().try(
     Joi.string(),
     Joi.array().items(navigationItemSchema),
@@ -81,6 +86,13 @@ Joi.assert(
 );
 
 site.docsPath = resolveExistingPath(SITE_CWD, site.docsPath);
+
+if (site.mdComponents) {
+  site.mdComponents.path = resolveExistingPath(
+    SITE_CWD,
+    site.mdComponents.path,
+  );
+}
 
 if (site.navigation) {
   const navigationData = site.navigation;

--- a/packages/okidoc-site/site/package.json
+++ b/packages/okidoc-site/site/package.json
@@ -21,6 +21,7 @@
     "gatsby-source-filesystem": "1.5.34",
     "gatsby-transformer-remark": "1.7.40",
     "github-slugger": "^1.2.0",
+    "hast-to-hyperscript": "^4.0.0",
     "joi": "^13.2.0",
     "prismjs": "^1.14.0",
     "prop-types": "^15.6.1",

--- a/packages/okidoc-site/site/plugins/gatsby-md-components/gatsby-ssr.js
+++ b/packages/okidoc-site/site/plugins/gatsby-md-components/gatsby-ssr.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+exports.onRenderBody = (
+  { setHeadComponents, setPostBodyComponents },
+  { externalStyles, externalScripts },
+) => {
+  if (externalStyles && externalStyles.length) {
+    const stylesToLoad = externalStyles.map((src, i) => (
+      <link
+        key={`doc-components-external-styles-${i}`}
+        rel="stylesheet"
+        href={src}
+      />
+    ));
+
+    setHeadComponents(stylesToLoad);
+  }
+
+  if (externalScripts && externalScripts.length) {
+    const scriptsToLoad = externalScripts.map((src, i) => (
+      <script key={`doc-components-external-scripts-${i}`} src={src} />
+    ));
+
+    setPostBodyComponents(scriptsToLoad);
+  }
+};

--- a/packages/okidoc-site/site/plugins/gatsby-md-components/package.json
+++ b/packages/okidoc-site/site/plugins/gatsby-md-components/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "gatsby-md-components"
+}

--- a/packages/okidoc-site/site/src/templates/md.js
+++ b/packages/okidoc-site/site/src/templates/md.js
@@ -5,6 +5,8 @@ import renderHtmlAst from '../utils/renderHtmlAst';
 import Navigation from '../components/Navigation';
 import CatchDemoLinks from '../components/CatchDemoLinks';
 
+import getPageHeadingsAndHtmlAst from '../utils/getPageHeadingsAndHtmlAst';
+
 import '../assets/stylesheets/prism.scss';
 
 const SIMPLE_LAYOUT = 'simple';
@@ -25,39 +27,10 @@ function Template({ match, location, data: { site, page } }) {
     );
   }
 
-  const headings = page.headings;
-  const htmlAst = page.htmlAst;
+  const { headings, htmlAst } = getPageHeadingsAndHtmlAst(page);
 
-  const frontMatter = page.frontmatter;
-  const includes = frontMatter && frontMatter.include;
-  const layout = (frontMatter && frontMatter.layout) || 'two-column';
+  const layout = (page.frontmatter && page.frontmatter.layout) || 'two-column';
   const isSimpleLayout = layout === SIMPLE_LAYOUT;
-
-  if (includes) {
-    includes.forEach(file => {
-      if (!file) {
-        console.error(
-          `'${
-            location.pathname
-          }': invalid file path in md front matter 'include' property`,
-        );
-      }
-
-      if (!file.childMarkdownRemark) {
-        console.error(
-          `'${
-            location.pathname
-          }': invalid file in md front matter 'include' property`,
-        );
-        return;
-      }
-
-      const childMarkdownRemark = file.childMarkdownRemark;
-
-      headings.push(...childMarkdownRemark.headings);
-      htmlAst.children.push(...childMarkdownRemark.htmlAst.children);
-    });
-  }
 
   return (
     <Fragment>

--- a/packages/okidoc-site/site/src/utils/getPageHeadingsAndHtmlAst.js
+++ b/packages/okidoc-site/site/src/utils/getPageHeadingsAndHtmlAst.js
@@ -1,0 +1,42 @@
+function getPageHeadingsAndHtmlAst(page) {
+  const headings = [...page.headings];
+  const htmlAst = {
+    type: 'root',
+    children: [...page.htmlAst.children],
+  };
+
+  const includes = page.frontmatter && page.frontmatter.include;
+
+  if (includes && includes.length) {
+    includes.forEach(file => {
+      if (!file) {
+        console.error(
+          `'${
+            location.pathname
+          }': invalid file path in md front matter 'include' property`,
+        );
+      }
+
+      if (!file.childMarkdownRemark) {
+        console.error(
+          `'${
+            location.pathname
+          }': invalid file in md front matter 'include' property`,
+        );
+        return;
+      }
+
+      const childMarkdownRemark = file.childMarkdownRemark;
+
+      headings.push(...childMarkdownRemark.headings);
+      htmlAst.children.push(...childMarkdownRemark.htmlAst.children);
+    });
+  }
+
+  return {
+    headings,
+    htmlAst,
+  };
+}
+
+export default getPageHeadingsAndHtmlAst;

--- a/packages/okidoc-site/site/src/utils/renderHtmlAst.js
+++ b/packages/okidoc-site/site/src/utils/renderHtmlAst.js
@@ -1,0 +1,63 @@
+import React, { Fragment } from 'react';
+import toH from 'hast-to-hyperscript';
+
+const FRAGMENT_TAG_NAME = '__Fragment__';
+
+function getReactElement(name, components) {
+  if (name === FRAGMENT_TAG_NAME) {
+    return Fragment;
+  }
+
+  if (components && components.hasOwnProperty(name)) {
+    return components[name];
+  }
+
+  return name;
+}
+
+function getReactChildren(name, children) {
+  if (['table', 'thead', 'tbody', 'tr', 'td'].indexOf(name) !== -1) {
+    // cleanup empty texts from children to prevent react warnings like
+    // "Whitespace text nodes cannot appear as a child of table/thead/..."
+    return (
+      children &&
+      children.filter(
+        element => typeof element !== 'string' || !!element.trim(),
+      )
+    );
+  }
+
+  return children;
+}
+
+/**
+ * Compile HAST to React.
+ * @param node
+ * @param components
+ */
+function renderHtmlAst(node, { components }) {
+  if (node.type === 'root') {
+    if (node.children.length === 1 && node.children[0].type === 'element') {
+      node = node.children[0];
+    } else {
+      node = {
+        type: 'element',
+        tagName: FRAGMENT_TAG_NAME,
+        properties: {},
+        children: node.children,
+      };
+    }
+  }
+
+  function h(name, props, children) {
+    return React.createElement(
+      getReactElement(name, components),
+      props,
+      getReactChildren(name, children),
+    );
+  }
+
+  return toH(h, node);
+}
+
+export default renderHtmlAst;


### PR DESCRIPTION
inspired by https://using-remark.gatsbyjs.org/custom-components/ so has same caveats

Example:
```yml
# site.yml
...
mdComponents:
  path: ./docs/playground-components.js
  # NOTE: `externalScripts` and `externalLinks` may affect your scripts and styles
  # externalStyles: []
  # externalScripts: []
...
```
```js
// playground-components.js

import React from 'react';

export default {
  counter: () => <span>!COUNTER!</span>
};
```

```md
<!-- index.md -->

# Counter

<counter></counter>
```

The additional example for playable:
https://github.com/wix/playable/compare/feature/okidoc-demo-components
