### PR TITLE
feat(okidoc-site): add ability to use nested pages navigation

### DIFF
--- a/docs/okidoc-site-navigation.md
+++ b/docs/okidoc-site-navigation.md
@@ -1,0 +1,38 @@
+---
+title: "Documentation site navigation"
+layout: simple
+---
+
+# Documentation site navigation
+
+To configure your site navigation, use config `navigation` field:
+
+```yaml
+navigation:
+ - path: /config
+   title: Configuration
+ - path: /methods
+   title: Methods
+```
+
+> `path` property is path to markdown file (without `.md` extension) inside `./docs` directory
+
+To add nested items on navigation item, use `items` prop:
+
+```yaml
+navigation:
+  - title: Editor
+    items:
+      - path: /pages
+        title: Pages
+      ...
+  - title: Document
+    items:
+      - path: /components
+        title: Components
+      - title: Config
+        items:
+          ...
+```
+
+> if nested `items` array not provided on navigation item, `path` property is required

--- a/docs/partial/okidoc-site.md
+++ b/docs/partial/okidoc-site.md
@@ -53,6 +53,8 @@ navigation:
    title: Methods
 ```
 
+Read more about cross-page navigation [here](/okidoc-site-navigation)
+
 Run `okidoc-site` script
 
 ```sh

--- a/packages/okidoc-site/site/.gitignore
+++ b/packages/okidoc-site/site/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .cache/
 public/
+src/__navigation.json
 

--- a/packages/okidoc-site/site/gatsby-config.js
+++ b/packages/okidoc-site/site/gatsby-config.js
@@ -12,8 +12,8 @@ if (site.config.githubLink) {
   process.env.GATSBY_GITHUB_LINK = site.config.githubLink;
 }
 
-if (site.navigation && site.navigation.length) {
-  process.env.GATSBY_WITH_NAVIGATION = true;
+if (site.navigation) {
+  process.env.GATSBY_NAVIGATION_PATH = site.navigation;
 }
 
 const defaultSiteMetadata = {
@@ -25,20 +25,12 @@ const defaultSiteMetadata = {
 // https://www.gatsbyjs.org/docs/gatsby-config/
 module.exports = {
   pathPrefix: site.config.pathPrefix,
-  // NOTE: Force graphql schema to add title, description, keywords and navigation fields if they not provided
+  // NOTE: Force graphql schema to add title, description, keywords fields if they not provided
   // TODO: figure out how to add this fields via gatsby api (https://github.com/gatsbyjs/gatsby/issues/3726)
   siteMetadata: Object.assign(
     {},
     defaultSiteMetadata,
     site.config.siteMetadata,
-    {
-      navigation: site.navigation || [
-        {
-          path: '/',
-          title: 'Home',
-        },
-      ],
-    },
   ),
   plugins: [
     'gatsby-plugin-react-next',

--- a/packages/okidoc-site/site/src/components/Navigation/Navigation.js
+++ b/packages/okidoc-site/site/src/components/Navigation/Navigation.js
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 
 import NavButton from './NavButton';
 import NavigationHeadings from './NavigationHeadings';
+import NavigationItems from './NavigationItems';
 import classNames from 'classnames';
-import Link from 'gatsby-link';
-
-const withNavigation = process.env.GATSBY_WITH_NAVIGATION === 'true';
 
 class Navigation extends Component {
   constructor(props) {
@@ -33,16 +31,11 @@ class Navigation extends Component {
         />
         <div className={classNames('toc-wrapper', { open: isOpen })}>
           <NavigationHeadings headings={headings} />
-          {withNavigation &&
-            navigation &&
+          {navigation &&
             navigation.length > 0 && (
-              <ul className="toc-footer">
-                {navigation.map(({ path, title }) => (
-                  <li key={path}>
-                    <Link to={path}>{title}</Link>
-                  </li>
-                ))}
-              </ul>
+              <div className="toc-footer">
+                <NavigationItems items={navigation} />
+              </div>
             )}
         </div>
       </Fragment>

--- a/packages/okidoc-site/site/src/components/Navigation/NavigationItems/NavigationItems.js
+++ b/packages/okidoc-site/site/src/components/Navigation/NavigationItems/NavigationItems.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Link from 'gatsby-link';
+
+function NavigationItems({ items }) {
+  return (
+    <ul>
+      {items.map((item, i) => (
+        <li key={item.path + '_' + i}>
+          {item.path ? (
+            <Link to={item.path}>{item.title}</Link>
+          ) : (
+            <a>{item.title}</a>
+          )}
+          {item.items &&
+            item.items.length && <NavigationItems items={item.items} />}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+NavigationItems.propTypes = {
+  items: PropTypes.array.isRequired,
+};
+
+export default NavigationItems;

--- a/packages/okidoc-site/site/src/components/Navigation/NavigationItems/index.js
+++ b/packages/okidoc-site/site/src/components/Navigation/NavigationItems/index.js
@@ -1,0 +1,1 @@
+export { default } from './NavigationItems';

--- a/packages/okidoc-site/site/src/templates/md.js
+++ b/packages/okidoc-site/site/src/templates/md.js
@@ -8,6 +8,10 @@ import '../assets/stylesheets/prism.scss';
 const SIMPLE_LAYOUT = 'simple';
 const INDEX_PAGE_REQUIRED_MESSAGE = `For site index page create <code>./docs/index.md</code> file`;
 
+const NAVIGATION = process.env.GATSBY_NAVIGATION_PATH
+  ? require(process.env.GATSBY_NAVIGATION_PATH)
+  : [];
+
 function Template({ match, location, data: { site, page } }) {
   if (!page && match.path === '/') {
     page = {
@@ -35,7 +39,7 @@ function Template({ match, location, data: { site, page } }) {
       <Navigation
         location={location}
         headings={headings}
-        navigation={site.siteMetadata.navigation}
+        navigation={NAVIGATION}
       />
       <div className={`page-wrapper ${layout}-layout`}>
         {!isSimpleLayout && <div className="dark-box" />}
@@ -52,9 +56,7 @@ Template.propTypes = {
   location: PropTypes.any.isRequired,
   data: PropTypes.shape({
     site: PropTypes.shape({
-      siteMetadata: PropTypes.shape({
-        navigation: PropTypes.array.isRequired,
-      }),
+      siteMetadata: PropTypes.object,
     }),
     page: PropTypes.shape({
       headings: PropTypes.array.isRequired,
@@ -66,10 +68,7 @@ Template.propTypes = {
 export const siteFragment = graphql`
   fragment mdTemplateSiteFields on Site {
     siteMetadata {
-      navigation {
-        path
-        title
-      }
+      title
     }
   }
 `;


### PR DESCRIPTION
example:

![image](https://user-images.githubusercontent.com/2445828/39301355-7186d926-4957-11e8-923f-c2ec732c1f50.png)

```yml
# /site.yml
navigation:
  - title: Editor
    items:
      - path: /panels
        title: Panels
      - path: /pages
        title: Pages
  - title: Document
    items:
      - path: /components
        title: Components
      - path: /controllers
        title: Controllers
      - path: /routers
        title: Routers
```

closes #27