### PR TITLE
feat(okidoc-site): allow to use `okidoc-site` commands without configPath

### DIFF
--- a/packages/okidoc-site/bin/okidoc-site.js
+++ b/packages/okidoc-site/bin/okidoc-site.js
@@ -1,70 +1,37 @@
 #!/usr/bin/env node
 
-const path = require('path');
-const fs = require('fs');
-const yaml = require('yamljs');
-const spawn = require('cross-spawn');
-const copy = require('ncp').ncp;
+const program = require('caporal');
+const pkg = require('../package.json');
 
-// NOTE: ignore first 2 arguments (node and path of this file)
-const [command, siteYamlPath] = process.argv.slice(2);
+const runCLI = require('../cli');
 
-const ALLOWED_COMMANDS = ['build', 'develop'];
-const SITE_PATH = path.join(__dirname, '../site');
-const RUN_EXAMPLE = `
-  example:
-    '> okidoc-site ${ALLOWED_COMMANDS[0]} ./path/to/site.yml'
-`;
+const DEFAULT_CONFIG_PATH = './site.yml';
 
-if (!command || !ALLOWED_COMMANDS.includes(command)) {
-  throw new Error(
-    `'command' should be one of ${JSON.stringify(ALLOWED_COMMANDS)}.
-    ${RUN_EXAMPLE}`,
-  );
-}
-
-if (!siteYamlPath) {
-  throw new Error(
-    `'okidoc-site' config parameter not provided.
-    ${RUN_EXAMPLE}`,
-  );
-}
-
-if (!fs.existsSync(siteYamlPath)) {
-  throw new Error(
-    `site yaml path should be valid path.
-    '${siteYamlPath}' is not exists.
-    ${RUN_EXAMPLE}`,
-  );
-}
-
-const site = yaml.load(siteYamlPath);
-const SITE_DIST_PATH = path.resolve(site.distPath || './site');
-
-const siteCommand = spawn('npm', ['run', command], {
-  cwd: SITE_PATH,
-  stdio: 'inherit',
-  env: {
-    ...process.env,
-    SITE_CWD: process.cwd(),
-    SITE_YAML_PATH: path.resolve(siteYamlPath),
-  },
-});
-
-if (command === 'build') {
-  siteCommand.on('close', code => {
-    // NOTE: only success build should be copied
-    if (code !== 0) {
-      return;
-    }
-
-    // NOTE: cleanup prev build version
-    spawn.sync('rm', ['-rf', SITE_DIST_PATH], { stdio: 'inherit' });
-
-    copy(path.join(SITE_PATH, 'public'), SITE_DIST_PATH, err => {
-      if (!err) {
-        console.log(`open '${SITE_DIST_PATH}' to browse site build`);
-      }
-    });
+program
+  .version(pkg.version)
+  .description('okidoc-site')
+  .command(
+    'develop',
+    `Start development server. Watches files, rebuilds, and hot reloads if something changes`,
+  )
+  .argument(
+    '[configPath]',
+    'Config file path',
+    program.STRING,
+    DEFAULT_CONFIG_PATH,
+  )
+  .action(({ configPath }, {}, logger) => {
+    runCLI('develop', { configPath }, logger);
+  })
+  .command('build', `Build a Gatsby project`)
+  .argument(
+    '[configPath]',
+    'Config file path',
+    program.STRING,
+    DEFAULT_CONFIG_PATH,
+  )
+  .action(({ configPath }, {}, logger) => {
+    runCLI('build', { configPath }, logger);
   });
-}
+
+program.parse(process.argv);

--- a/packages/okidoc-site/cli.js
+++ b/packages/okidoc-site/cli.js
@@ -1,0 +1,54 @@
+const path = require('path');
+const yaml = require('yamljs');
+const spawn = require('cross-spawn');
+const copy = require('ncp').ncp;
+
+function clean(directoryPath) {
+  spawn.sync('rm', ['-rf', directoryPath], { stdio: 'inherit' });
+}
+
+function runCLI(command, { configPath }, logger) {
+  let site;
+
+  try {
+    site = yaml.load(configPath);
+  } catch (e) {
+    logger.error(
+      `Could not parse config file ('${configPath}'):\n ${e.message}`,
+    );
+    return;
+  }
+
+  const SITE_PATH = path.join(__dirname, './site');
+  const SITE_DIST_PATH = path.resolve(site.distPath || './site');
+
+  const siteCommand = spawn('npm', ['run', command], {
+    cwd: SITE_PATH,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      SITE_CWD: process.cwd(),
+      SITE_YAML_PATH: path.resolve(configPath),
+    },
+  });
+
+  if (command === 'build') {
+    siteCommand.on('close', code => {
+      // NOTE: only success build should be copied
+      if (code !== 0) {
+        return;
+      }
+
+      // NOTE: cleanup prev build version
+      clean(SITE_DIST_PATH);
+
+      copy(path.join(SITE_PATH, 'public'), SITE_DIST_PATH, err => {
+        if (!err) {
+          logger.log(`open '${SITE_DIST_PATH}' to browse site build`);
+        }
+      });
+    });
+  }
+}
+
+module.exports = runCLI;

--- a/packages/okidoc-site/package.json
+++ b/packages/okidoc-site/package.json
@@ -15,6 +15,7 @@
     "postinstall": "cd site && npm install"
   },
   "dependencies": {
+    "caporal": "^0.10.0",
     "cross-spawn": "^6.0.4",
     "ncp": "^2.0.0",
     "yamljs": "^0.3.0"


### PR DESCRIPTION
Use caporal for better user experience with lib CLI. `configPath` param now optional and has default value `./site.yml`.