### PR TITLE
fix(okidoc-site): fix issue with headings with same name on one page

### DIFF
--- a/packages/okidoc-site/site/package.json
+++ b/packages/okidoc-site/site/package.json
@@ -29,6 +29,7 @@
     "react-dom": "^16.3.2",
     "react-helmet": "^5.2.0",
     "react-modal": "^3.4.4",
+    "unist-util-visit": "^1.3.1",
     "yamljs": "^0.3.0"
   }
 }

--- a/packages/okidoc-site/site/src/utils/getPageHeadingsAndHtmlAst.js
+++ b/packages/okidoc-site/site/src/utils/getPageHeadingsAndHtmlAst.js
@@ -1,3 +1,28 @@
+import visit from 'unist-util-visit';
+import Slugger from 'github-slugger';
+
+const HEADING_TAG_PATTERN = /^h[1-6]$/;
+
+function fixHeadingLinks(htmlAst) {
+  const slugger = new Slugger();
+
+  visit(htmlAst, 'element', element => {
+    if (HEADING_TAG_PATTERN.test(element.tagName)) {
+      const id = element.properties.id;
+      const slug = slugger.slug(id);
+
+      if (id !== slug) {
+        element.properties.id = slug;
+        element.children.forEach(child => {
+          if (child.type === 'element' && child.tagName === 'a') {
+            child.properties.href = `#${slug}`;
+          }
+        });
+      }
+    }
+  });
+}
+
 function getPageHeadingsAndHtmlAst(page) {
   const headings = [...page.headings];
   const htmlAst = {
@@ -31,6 +56,9 @@ function getPageHeadingsAndHtmlAst(page) {
       headings.push(...childMarkdownRemark.headings);
       htmlAst.children.push(...childMarkdownRemark.htmlAst.children);
     });
+
+    // NOTE: fix heading link after joining md includes
+    fixHeadingLinks(htmlAst);
   }
 
   return {


### PR DESCRIPTION
if different md files included to one page via `frontmatter` `include` has heading with the same name, heading links could be invalid.
This change should fix it