### PR TITLE
Migrate to babel7

### DIFF
--- a/config/jest/babelTransform.js
+++ b/config/jest/babelTransform.js
@@ -1,0 +1,15 @@
+const babelJest = require('babel-jest');
+
+module.exports = babelJest.createTransformer({
+  // NOTE: babel 7 uses different approach with .babelrc file loading
+  // so force it to look .babelrc on every monorepo package
+  // https://babeljs.io/docs/en/next/config-files#6x-vs-7x-babelrc-loading
+  // https://babeljs.io/docs/en/next/options#babelrcroots
+  babelrcRoots: [
+    // Keep the root as a root
+    '.',
+
+    // Also consider monorepo packages "root" and load their .babelrc files.
+    './packages/*',
+  ],
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '\\.js$': '<rootDir>/config/jest/babelTransform.js',
+  },
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/packages/okidoc-md/lib/',
+    '/packages/okidoc-site/site/',
+    '/fixtures/',
+  ],
+  collectCoverageFrom: [
+    'packages/okidoc-md/src/buildDocumentationSource/**/*.js',
+    'packages/okidoc-md/src/buildMarkdown/**/*.js',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -24,29 +24,16 @@
     ]
   },
   "devDependencies": {
-    "@babel/core": "7.0.0-beta.40",
-    "babel-core": "7.0.0-bridge.0",
-    "babel-jest": "^22.4.3",
+    "@babel/core": "7.0.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^23.4.2",
     "gh-pages": "^1.1.0",
     "husky": "0.14.3",
-    "jest": "^22.4.0",
+    "jest": "^23.5.0",
     "lerna": "^2.11.0",
     "lint-staged": "^7.0.5",
     "prettier": "^1.12.1",
     "regenerator-runtime": "^0.11.1"
-  },
-  "jest": {
-    "testEnvironment": "node",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/packages/okidoc-md/lib/",
-      "/packages/okidoc-site/site/",
-      "/fixtures/"
-    ],
-    "collectCoverageFrom": [
-      "packages/okidoc-md/src/buildDocumentationSource/**/*.js",
-      "packages/okidoc-md/src/buildMarkdown/**/*.js"
-    ]
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/okidoc-md/package.json
+++ b/packages/okidoc-md/package.json
@@ -23,10 +23,10 @@
     "node": ">=8"
   },
   "dependencies": {
-    "@babel/code-frame": "7.0.0-beta.40",
-    "@babel/generator": "7.0.0-beta.40",
-    "@babel/traverse": "7.0.0-beta.40",
-    "@babel/types": "7.0.0-beta.40",
+    "@babel/code-frame": "7.0.0",
+    "@babel/generator": "7.0.0",
+    "@babel/traverse": "7.0.0",
+    "@babel/types": "7.0.0",
     "babylon": "7.0.0-beta.40",
     "caporal": "^0.10.0",
     "doctrine-temporary-fork": "2.0.1",
@@ -42,10 +42,10 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
-    "@babel/cli": "7.0.0-beta.40",
-    "@babel/core": "7.0.0-beta.40",
-    "@babel/plugin-proposal-object-rest-spread": "7.0.0-beta.40",
-    "@babel/preset-env": "7.0.0-beta.40"
+    "@babel/cli": "7.0.0",
+    "@babel/core": "7.0.0",
+    "@babel/plugin-proposal-object-rest-spread": "7.0.0",
+    "@babel/preset-env": "7.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
babel 7 uses a different approach with `.babelrc` config loading

To force it to look `.babelrc` on every monorepo package added `config/jest/babelTransform.js` with `babelrcRoots`

https://babeljs.io/docs/en/next/config-files#6x-vs-7x-babelrc-loading
https://babeljs.io/docs/en/next/options#babelrcroots

closes #50 