### PR TITLE
WIP: Generate documentation for common interfaces

### DIFF
--- a/docs/partial/okidoc-md.md
+++ b/docs/partial/okidoc-md.md
@@ -32,21 +32,27 @@ function subscribe(eventName: string, fn: Function) {}
 Add yaml config (default config path is `./docs.yml`):
 
 ```yaml
+# [optional] Define page settings for common types page (used if there are more than one docs page)
+commonTypes:
+  title: My Types
+  path: my-types.md
+
 # Get files using `entry` or/and `glob` (could be `.js` or `.ts` files),
 # find api methods by `@doc UI` tag in JSDoc and generate markdown to `partial/ui.md` file.
-- path: partial/ui.md
-  title: UI API Methods
-  # [optional] if provided, only `entry` file dependencies will be parsed
-  entry: src/index.ts
-  # [optional] required if `entry` not provided
-  glob: src/**/*.ts
-  # tag name have to match `@doc UI` in JSDoc
-  tag: UI
+docs:
+  - path: partial/ui.md
+    title: UI API Methods
+    # [optional] if provided, only `entry` file dependencies will be parsed
+    entry: src/index.ts
+    # [optional] required if `entry` not provided
+    glob: src/**/*.ts
+    # tag name have to match `@doc UI` in JSDoc
+    tag: UI
 
-- path: partial/events.md
-  title: Events API
-  glob: src/**/*.ts
-  tag: Events
+  - path: partial/events.md
+    title: Events API
+    glob: src/**/*.ts
+    tag: Events
 ```
 
 > NOTE: With `entry` option, all dependency file source will be parsed for doc. Not only imported/exported part.

--- a/packages/okidoc-md/bin/okidoc-md.js
+++ b/packages/okidoc-md/bin/okidoc-md.js
@@ -17,6 +17,9 @@ program
     runCLI({
       configPath: options.config || args.configPath,
       outputDir: options.output || args.outputDir,
+    }).catch(error => {
+      console.error('An error occurred while building documentation.', error);
+      process.exit(1);
     });
   });
 

--- a/packages/okidoc-md/package.json
+++ b/packages/okidoc-md/package.json
@@ -45,7 +45,9 @@
     "@babel/cli": "7.0.0",
     "@babel/core": "7.0.0",
     "@babel/plugin-proposal-object-rest-spread": "7.0.0",
-    "@babel/preset-env": "7.0.0"
+    "@babel/preset-env": "7.0.0",
+    "fs-extra": "^7.0.0",
+    "tempy": "^0.2.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/packages/okidoc-md/src/__tests__/__snapshots__/common-types-md.spec.js.snap
+++ b/packages/okidoc-md/src/__tests__/__snapshots__/common-types-md.spec.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with common types should render doc markdown for common types 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# Types
+
+## IRunResult
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">MEMBERS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>x</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`with common types should use common types config if any 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# My Types
+
+## IRunResult
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">MEMBERS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>x</code>
+        </td>
+        <td>
+            <div class=\\"type\\">number</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;

--- a/packages/okidoc-md/src/__tests__/common-types-md.spec.js
+++ b/packages/okidoc-md/src/__tests__/common-types-md.spec.js
@@ -1,0 +1,81 @@
+import setupFS, { fromFixtures } from '../testUtils/setupFS';
+import runCLI from '../cli';
+
+import path from 'path';
+
+describe('with common types', function() {
+  const cwd = process.cwd();
+
+  afterEach(() => {
+    process.chdir(cwd);
+  });
+
+  it('should render doc markdown for common types', async () => {
+    const testFS = setupFS(
+      fromFixtures(path.join(__dirname, '/fixtures/common-types-md'), [
+        'src/types.ts',
+        'src/App.ts',
+        'src/AppTwo.ts',
+        'docs.yml',
+      ]),
+    );
+
+    process.chdir(testFS.cwd);
+
+    await runCLI({
+      configPath: testFS.files['/docs.yml'].path,
+      outputDir: testFS.files['/docs'].path,
+    });
+
+    const app = testFS.files['/docs/app.md'].content;
+    const types = testFS.files['/docs/types.md'].content;
+
+    expect(app.includes('## IRunResult')).toBeFalsy(); // should not have type definition in doc
+    expect(types).toMatchSnapshot();
+  });
+
+  it('should use common types config if any', async () => {
+    const testFS = setupFS(
+      fromFixtures(path.join(__dirname, '/fixtures/common-types-md'), [
+        'src/types.ts',
+        'src/App.ts',
+        'src/AppTwo.ts',
+        'docs-with-common-types.yml',
+      ]),
+    );
+
+    process.chdir(testFS.cwd);
+
+    await runCLI({
+      configPath: testFS.files['/docs-with-common-types.yml'].path,
+      outputDir: testFS.files['/docs'].path,
+    });
+
+    const types = testFS.files['/docs/my-types.md'].content;
+
+    expect(types.includes('# My Types')).toBeTruthy();
+    expect(types).toMatchSnapshot();
+  });
+
+  it('should render doc markdown for common types inside same md for single page documentation', async () => {
+    const testFS = setupFS(
+      fromFixtures(path.join(__dirname, '/fixtures/common-types-md'), [
+        'src/types.ts',
+        'src/App.ts',
+        'docs-single.yml',
+      ]),
+    );
+
+    process.chdir(testFS.cwd);
+
+    await runCLI({
+      configPath: testFS.files['/docs-single.yml'].path,
+      outputDir: testFS.files['/docs'].path,
+    });
+
+    expect(
+      testFS.files['/docs/app.md'].content.includes('## IRunResult'),
+    ).toBeTruthy(); // should have type definition in doc
+    expect(testFS.files['/docs/types.md'].exists).toBeFalsy();
+  });
+});

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs-single.yml
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs-single.yml
@@ -1,0 +1,4 @@
+- path: app.md
+  title: App
+  entry: src/App.ts
+  tag: app

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs-with-common-types.yml
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs-with-common-types.yml
@@ -1,0 +1,14 @@
+commonTypes:
+  title: My Types
+  path: my-types.md
+
+docs:
+  - path: app.md
+    title: App
+    entry: src/App.ts
+    tag: app
+
+  - path: app-two.md
+    title: AppTwo
+    entry: src/AppTwo.ts
+    tag: app-two

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs.yml
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/docs.yml
@@ -1,0 +1,9 @@
+- path: app.md
+  title: App
+  entry: src/App.ts
+  tag: app
+
+- path: app-two.md
+  title: AppTwo
+  entry: src/AppTwo.ts
+  tag: app-two

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/App.ts
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/App.ts
@@ -1,0 +1,14 @@
+import { IRunResult } from './types';
+
+/**
+ * @doc app
+ */
+class App {
+  run(): IRunResult {
+    return {
+      x: 1
+    };
+  }
+}
+
+export default App;

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/AppTwo.ts
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/AppTwo.ts
@@ -1,0 +1,14 @@
+import { IRunResult } from './types';
+
+/**
+ * @doc app-two
+ */
+class AppTwo {
+  run(): IRunResult {
+    return {
+      x: 1
+    };
+  }
+}
+
+export default AppTwo;

--- a/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/types.ts
+++ b/packages/okidoc-md/src/__tests__/fixtures/common-types-md/src/types.ts
@@ -1,0 +1,5 @@
+interface IRunResult {
+  x: number;
+}
+
+export { IRunResult };

--- a/packages/okidoc-md/src/buildDocumentation.js
+++ b/packages/okidoc-md/src/buildDocumentation.js
@@ -1,40 +1,30 @@
-import documentation from 'documentation';
-import { codeFrameColumns } from '@babel/code-frame';
-
 import buildDocumentationSource from './buildDocumentationSource';
-import buildMarkdown from './buildMarkdown';
+import buildDocumentationMarkdown from './utils/buildDocumentationMarkdown';
 
-function buildDocumentation({ title, entry, source, pattern, tag, visitor }) {
+function buildDocumentation({
+  title,
+  entry,
+  source,
+  pattern,
+  tag,
+  visitor,
+  interfaces,
+  excludeKind = [],
+}) {
   const documentationSource = buildDocumentationSource({
     entry,
     source,
     pattern,
     tag,
     visitor,
+    interfaces,
   });
 
-  return documentation
-    .build([{ source: documentationSource || ' ' }], { shallow: true })
-    .then(
-      comments =>
-        buildMarkdown(comments, {
-          title: title,
-        }),
-      error => {
-        if (error.loc) {
-          error.codeFrame = codeFrameColumns(documentationSource, {
-            start: error.loc,
-          });
-          error.message += `\n${error.codeFrame}`;
-        }
-
-        error.message = `"${title}" documentation source${
-          source ? '' : ` (${entry || pattern})`
-        } - ${error.message}`;
-
-        throw error;
-      },
-    );
+  return buildDocumentationMarkdown(documentationSource, {
+    title,
+    sourceInfo: entry || pattern,
+    excludeKind,
+  });
 }
 
 export default buildDocumentation;

--- a/packages/okidoc-md/src/buildDocumentation.spec.js
+++ b/packages/okidoc-md/src/buildDocumentation.spec.js
@@ -1,5 +1,7 @@
 import buildDocumentation from './buildDocumentation';
 
+// TODO: move to __tests__ dir, run with cli via setupFS test utils
+
 describe('buildDocumentation', () => {
   it('should build documentation for class ', async () => {
     const sourceCode = `

--- a/packages/okidoc-md/src/buildDocumentationForCommonTypes.js
+++ b/packages/okidoc-md/src/buildDocumentationForCommonTypes.js
@@ -1,0 +1,16 @@
+import generate from '@babel/generator';
+
+import buildProgram from './utils/buildProgram';
+import buildDocumentationMarkdown from './utils/buildDocumentationMarkdown';
+
+function buildDocumentationForCommonTypes(interfaces, { title }) {
+  const typesProgramAST = buildProgram(Object.values(interfaces));
+  const typesSource = generate(typesProgramAST).code;
+
+  return buildDocumentationMarkdown(typesSource, {
+    title: title,
+    sourceInfo: 'common types',
+  });
+}
+
+export default buildDocumentationForCommonTypes;

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/__snapshots__/buildDocumentationSource.spec.js.snap
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/__snapshots__/buildDocumentationSource.spec.js.snap
@@ -2,6 +2,11 @@
 
 exports[`buildDocumentationSource by source entry should extract documentation source from entry dependencies 1`] = `
 "/**
+* SampleInterface
+*/
+interface SampleInterface {}
+
+/**
 * View
 */
 class View {
@@ -55,6 +60,11 @@ class Component {
 
 exports[`buildDocumentationSource by source entry should extract documentation source from entry dependencies 2`] = `
 "/**
+* SampleInterface
+*/
+interface SampleInterface {}
+
+/**
 * Events
 */
 class Events {
@@ -81,6 +91,11 @@ exports[`buildDocumentationSource by source entry should show readable error if 
 
 exports[`buildDocumentationSource by source glob pattern should extract documentation source from files matched glob 1`] = `
 "/**
+* SampleInterface
+*/
+interface SampleInterface {}
+
+/**
 * Component
 */
 class Component {
@@ -134,6 +149,11 @@ class View {
 
 exports[`buildDocumentationSource by source glob pattern should extract documentation source from files matched glob 2`] = `
 "/**
+* SampleInterface
+*/
+interface SampleInterface {}
+
+/**
 * mountComponent
 */
 function mountComponent(component: Function, node: Node) {}

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/buildDocumentationSource.spec.js
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/buildDocumentationSource.spec.js
@@ -433,6 +433,19 @@ describe('buildDocumentationSource', () => {
         });
       }).toThrowErrorMatchingSnapshot();
     });
+
+    it('should extract interfaces from entry dependencies', () => {
+      const interfaces = {};
+
+      // TODO: review this test before merge PR
+      buildDocumentationSource({
+        entry: require.resolve('./fixtures/src/index.ts'),
+        tag: 'UI',
+        interfaces,
+      });
+
+      expect(Object.keys(interfaces).length).toBe(1);
+    });
   });
 
   describe('by source glob pattern', () => {

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/fixtures/src/SampleInterface.ts
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/fixtures/src/SampleInterface.ts
@@ -1,0 +1,6 @@
+/**
+ * SampleInterface
+ */
+interface SampleInterface {}
+
+export default SampleInterface;

--- a/packages/okidoc-md/src/buildDocumentationSource/__tests__/fixtures/src/View.ts
+++ b/packages/okidoc-md/src/buildDocumentationSource/__tests__/fixtures/src/View.ts
@@ -1,3 +1,5 @@
+import SampleInterface from './SampleInterface';
+
 /**
  * View
  * @doc UI

--- a/packages/okidoc-md/src/buildDocumentationSource/buildDocumentationSource.js
+++ b/packages/okidoc-md/src/buildDocumentationSource/buildDocumentationSource.js
@@ -2,9 +2,23 @@ import generate from '@babel/generator';
 
 import buildDocumentationSourceAST from './buildDocumentationSourceAST';
 
-function buildDocumentationSource({ entry, source, pattern, tag, visitor }) {
+function buildDocumentationSource({
+  entry,
+  source,
+  pattern,
+  tag,
+  visitor,
+  interfaces = {},
+}) {
   return generate(
-    buildDocumentationSourceAST({ entry, source, pattern, tag, visitor }),
+    buildDocumentationSourceAST({
+      entry,
+      source,
+      pattern,
+      tag,
+      visitor,
+      interfaces,
+    }),
   ).code;
 }
 

--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -926,6 +926,66 @@ create new entity
 "
 `;
 
+exports[`buildMarkdown for interface should list methods 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# IComponent
+
+Component description
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">MEMBERS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>componentMethod</code>
+        </td>
+        <td>
+            <code class=\\"function-type\\">function(): string</code>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown for interface should list properties 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# IComponent
+
+Component description
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">MEMBERS</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>componentProperty</code>
+        </td>
+        <td>
+            <div class=\\"type\\">string</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
 exports[`buildMarkdown with ApplicationType as return type should render markdown for methods with Array & interface as @returns type 1`] = `
 "<!-- Generated automatically. Update this documentation by updating the source code. -->
 

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -8,6 +8,42 @@ function getMarkdown(documentationSource, args) {
 }
 
 describe('buildMarkdown', () => {
+  describe('for interface', () => {
+    it('should list properties', async () => {
+      const documentationSource = `
+      /**
+      * Component description
+      */
+      interface IComponent {
+        /**
+        * Some property
+        */
+        componentProperty: string;
+      }
+    `;
+      const markdown = await getMarkdown(documentationSource);
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it('should list methods', async () => {
+      const documentationSource = `
+      /**
+      * Component description
+      */
+      interface IComponent {
+        /**
+        * Some method
+        */
+        componentMethod(): string;
+      }
+    `;
+      const markdown = await getMarkdown(documentationSource);
+
+      expect(markdown).toMatchSnapshot();
+    });
+  });
+
   describe('for class', () => {
     it('should render markdown for class with constructor', async () => {
       const documentationSource = `
@@ -245,7 +281,10 @@ describe('buildMarkdown', () => {
         }
       }
     `;
-      const markdown = await getMarkdown(documentationSource, { title });
+      const markdown = await getMarkdown(documentationSource, {
+        title,
+        excludeKind: ['interface'],
+      });
 
       expect(markdown).toMatchSnapshot();
     });
@@ -321,7 +360,10 @@ describe('buildMarkdown', () => {
       */
       function myFunc2(x: number, y:number): MyFuncResult {}
     `;
-      const markdown = await getMarkdown(documentationSource, { title });
+      const markdown = await getMarkdown(documentationSource, {
+        title,
+        excludeKind: ['interface'],
+      });
 
       expect(markdown).toMatchSnapshot();
     });
@@ -383,7 +425,10 @@ describe('buildMarkdown', () => {
         */
         function create(title: string): MyEntity {}
       `;
-      const markdown = await getMarkdown(documentationSource, { title });
+      const markdown = await getMarkdown(documentationSource, {
+        title,
+        excludeKind: ['interface'],
+      });
 
       expect(markdown).toMatchSnapshot();
     });
@@ -421,7 +466,10 @@ describe('buildMarkdown', () => {
         return {x: 1, y: 1};
       }
       `;
-      const markdown = await getMarkdown(documentationSource, { title });
+      const markdown = await getMarkdown(documentationSource, {
+        title,
+        excludeKind: ['interface'],
+      });
 
       expect(markdown).toMatchSnapshot();
     });
@@ -455,7 +503,10 @@ describe('buildMarkdown', () => {
         return [{x: 1, y: 1}];
       }
       `;
-      const markdown = await getMarkdown(documentationSource, { title });
+      const markdown = await getMarkdown(documentationSource, {
+        title,
+        excludeKind: ['interface'],
+      });
 
       expect(markdown).toMatchSnapshot();
     });

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/buildMarkdownAST.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/buildMarkdownAST.js
@@ -3,7 +3,7 @@ import renderComment from './renderComment';
 
 const GENERATOR_COMMENT = `<!-- Generated automatically. Update this documentation by updating the source code. -->`;
 
-function buildMarkdownAST(comments, { title } = {}) {
+function buildMarkdownAST(comments, { title, excludeKind = [] } = {}) {
   const docInterfaces = comments.filter(({ kind }) => kind === 'interface');
 
   // NOTE: to better understand `comments` format see:
@@ -24,6 +24,7 @@ function buildMarkdownAST(comments, { title } = {}) {
           renderComment(comment, {
             depth: depth + 1,
             interfaces: docInterfaces,
+            excludeKind,
           }),
         ),
       [],

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/getParamsFromInterface.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/getParamsFromInterface.js
@@ -1,0 +1,16 @@
+import parseMarkdown from './parseMarkdown';
+
+function getParamsFromInterface(_interface) {
+  return _interface.properties.map(property => {
+    const tag = _interface.tags.find(
+      tag => tag.title === 'property' && tag.name === property.name,
+    );
+
+    return {
+      ...property,
+      description: tag && parseMarkdown(tag.description),
+    };
+  });
+}
+
+export default getParamsFromInterface;

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
@@ -1,5 +1,6 @@
 import { Syntax } from './formatType';
-import parseMarkdown from './parseMarkdown';
+
+import getParamsFromInterface from './getParamsFromInterface';
 
 function isPromiseType(type) {
   return type.type === Syntax.NameExpression && type.name === 'Promise';
@@ -16,19 +17,6 @@ function getInterfaceByType(type, interfaces) {
         _interface.name === type.name && _interface.properties.length > 0,
     );
   }
-}
-
-function getParamsFromInterface(_interface) {
-  return _interface.properties.map(property => {
-    const tag = _interface.tags.find(
-      tag => tag.title === 'property' && tag.name === property.name,
-    );
-
-    return {
-      ...property,
-      description: tag && parseMarkdown(tag.description),
-    };
-  });
 }
 
 function parseReturnsComment(returns, interfaces) {

--- a/packages/okidoc-md/src/testUtils/setupFS.js
+++ b/packages/okidoc-md/src/testUtils/setupFS.js
@@ -1,0 +1,116 @@
+import path from 'path';
+import fs from 'fs-extra';
+import tempy from 'tempy';
+
+// NOTE: inspired by https://github.com/wix/haste/blob/v0.3.1/packages/haste-test-utils-core/src/fs-setup.js
+
+/**
+ * Setup temp directory with test utils
+ * @param {Object} fsObject
+ *
+ * @example
+ *
+ * const testFS = setupFS({
+ *   'src/constants.ts': 'export const X = 1;'
+ *   'src/index.ts': 'import { X } from './constants'
+ * })
+ *
+ * console.log(testFS.cwd)
+ * // /path/to/temp/directory
+ *
+ * console.log(testFS.files['src/index.ts'].path)
+ * // /path/to/temp/directory/src/index.ts
+ */
+function setupFS(fsObject = {}) {
+  const cwd = tempy.directory();
+
+  Object.keys(fsObject).forEach(fileName => {
+    fs.outputFileSync(path.join(cwd, fileName), fsObject[fileName]);
+  });
+
+  const createFileProxy = fileName => {
+    return new Proxy(
+      {},
+      {
+        get(target, prop) {
+          const filePath = path.join(cwd, fileName);
+
+          switch (prop) {
+            case 'content':
+              return fs.readFileSync(filePath, 'utf8');
+
+            case 'exists':
+              return fs.existsSync(filePath);
+
+            case 'path':
+              return filePath;
+
+            case 'write':
+              return content => fs.outputFileSync(filePath, content);
+
+            default:
+              return undefined;
+          }
+        },
+      },
+    );
+  };
+
+  const files = new Proxy(
+    {},
+    {
+      get: (target, fileName) => createFileProxy(fileName),
+    },
+  );
+
+  return {
+    cwd,
+    files,
+  };
+}
+
+function fromFixture(fixturesDir, fixtureFileName) {
+  return fs.readFileSync(path.join(fixturesDir, fixtureFileName), 'utf8');
+}
+
+/**
+ * @param {string} fixturesDir
+ * @param {string[]} fixturesFileNames
+ *
+ * @example
+ *
+ * setupFS(fromFixtures('/path/to/fixtures', [
+ *  '/src/index.ts',
+ *  '/docs.yml'
+ * ]))
+ */
+function fromFixtures(fixturesDir, fixturesFileNames) {
+  return fixturesFileNames.reduce((fsObject, fileName) => {
+    fsObject[fileName] = fromFixture(fixturesDir, fileName);
+
+    return fsObject;
+  }, {});
+}
+
+/**
+ * @param {string} fixturesDir
+ * @param {Object} fixturesMap
+ *
+ * @example
+ *
+ * setupFS(fromFixtures('/path/to/fixtures', {
+ *   'src/index.ts': 'src/invalid-index.ts',
+ *   'docs.yml': 'src/docs.yml'
+ * }))
+ */
+function fromFixturesMap(fixturesDir, fixturesMap) {
+  return Object.keys(fixturesMap).reduce((fsObject, fileName) => {
+    fsObject[fileName] = fromFixture(fixturesDir, fsObject[fileName]);
+
+    return fsObject;
+  }, {});
+}
+
+export { fromFixture, fromFixtures, fromFixturesMap };
+
+export default setupFS;

--- a/packages/okidoc-md/src/utils/buildDocumentationMarkdown.js
+++ b/packages/okidoc-md/src/utils/buildDocumentationMarkdown.js
@@ -1,0 +1,36 @@
+import documentation from 'documentation';
+import { codeFrameColumns } from '@babel/code-frame';
+
+import buildMarkdown from '../buildMarkdown';
+
+// @todo: redesign contract, remove all cases, just pass smth like context
+function buildDocumentationMarkdown(
+  documentationSource,
+  { title, sourceInfo, excludeKind },
+) {
+  return documentation
+    .build([{ source: documentationSource || ' ' }], { shallow: true })
+    .then(
+      comments =>
+        buildMarkdown(comments, {
+          title: title,
+          excludeKind,
+        }),
+      error => {
+        if (error.loc) {
+          error.codeFrame = codeFrameColumns(documentationSource, {
+            start: error.loc,
+          });
+          error.message += `\n${error.codeFrame}`;
+        }
+
+        error.message = `"${title}" documentation source${
+          !sourceInfo ? '' : ` (${sourceInfo})`
+        } - ${error.message}`;
+
+        throw error;
+      },
+    );
+}
+
+export default buildDocumentationMarkdown;

--- a/packages/okidoc-md/src/utils/buildProgram.js
+++ b/packages/okidoc-md/src/utils/buildProgram.js
@@ -1,0 +1,8 @@
+function buildProgram(...declarations) {
+  return {
+    type: 'Program',
+    body: declarations.reduce((result, item) => result.concat(item), []),
+  };
+}
+
+export default buildProgram;

--- a/packages/okidoc-md/src/utils/traverseEntries.js
+++ b/packages/okidoc-md/src/utils/traverseEntries.js
@@ -78,7 +78,7 @@ function traverseEntry(entryPath, visitors, { pattern, visited = [] } = {}) {
   );
 
   // TODO: ensure declarations are exported before add to doc
-  traverse(entryAST, visitors);
+  traverse(entryAST, visitors, null, { filePath: entryPath });
 }
 
 function traverseEntries(entry, visitors, { pattern }) {

--- a/packages/okidoc-md/src/utils/traverseFiles.js
+++ b/packages/okidoc-md/src/utils/traverseFiles.js
@@ -11,7 +11,7 @@ function traverseFiles(pattern, visitor) {
   }
 
   files.forEach(filePath => {
-    traverse(parseFile(filePath), visitor);
+    traverse(parseFile(filePath), visitor, null, { filePath });
   });
 }
 

--- a/packages/okidoc-md/src/utils/traverseSource.js
+++ b/packages/okidoc-md/src/utils/traverseSource.js
@@ -2,7 +2,7 @@ import traverse from '@babel/traverse';
 import parseSource from './parseSource';
 
 function traverseSource(source, visitors) {
-  traverse(parseSource(source), visitors);
+  traverse(parseSource(source), visitors, null, { filePath: 'source' });
 }
 
 export default traverseSource;


### PR DESCRIPTION
tasks:
- [x] render markdown for interfaces
- [x] extract and render common interfaces to separate file (`types.md`)
- [x] add config for common types rendering (update format `docs.yml`)
- [x] add e2e tests for `types.md` rendering
- [x] update docs about `docs.yml` fromat
- [x] allow to render interface right to the related doc (without extracting to `types.md`)?

Closes #46, Closes #57
Related issue #36 