### PR TITLE
[WIP] Documentationjs upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/README.md
 sitedist
 
 /coverage/
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
+    "setup": "npm i && botstrap",
     "bootstrap": "lerna bootstrap --hoist",
     "build": "npm run bootstrap",
     "okidoc-site": "node ./packages/okidoc-site/bin/okidoc-site.js",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.0.0",
+    "@types/jest": "^23.3.14",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "gh-pages": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "license": "MIT",
   "scripts": {
-    "setup": "npm i && botstrap",
     "bootstrap": "lerna bootstrap --hoist",
     "build": "npm run bootstrap",
     "okidoc-site": "node ./packages/okidoc-site/bin/okidoc-site.js",

--- a/packages/okidoc-md/package.json
+++ b/packages/okidoc-md/package.json
@@ -30,7 +30,7 @@
     "@babel/types": "7.0.0",
     "caporal": "^0.10.0",
     "doctrine-temporary-fork": "2.0.1",
-    "documentation": "8.1.2",
+    "documentation": "^12.0.3",
     "filing-cabinet": "^2.0.1",
     "glob": "^7.1.3",
     "lodash": "^4.17.10",

--- a/packages/okidoc-md/package.json
+++ b/packages/okidoc-md/package.json
@@ -25,9 +25,9 @@
   "dependencies": {
     "@babel/code-frame": "7.0.0",
     "@babel/generator": "7.0.0",
+    "@babel/parser": "^7.5.5",
     "@babel/traverse": "7.0.0",
     "@babel/types": "7.0.0",
-    "babylon": "7.0.0-beta.40",
     "caporal": "^0.10.0",
     "doctrine-temporary-fork": "2.0.1",
     "documentation": "8.1.2",

--- a/packages/okidoc-md/src/__snapshots__/buildDocumentation.spec.js.snap
+++ b/packages/okidoc-md/src/__snapshots__/buildDocumentation.spec.js.snap
@@ -48,7 +48,7 @@ exports[`buildDocumentation should handle optional method in interface, issue #6
 `;
 
 exports[`buildDocumentation should show readable error from \`documentation.js\` 1`] = `
-[SyntaxError: "Documentation" documentation source - Unexpected token, expected , (2:19)
+[SyntaxError: "Documentation" documentation source - Unexpected token, expected "," (2:19)
   1 | /** */
 > 2 | function fooGood<T extends {
     |                   ^

--- a/packages/okidoc-md/src/buildDocumentation.spec.js
+++ b/packages/okidoc-md/src/buildDocumentation.spec.js
@@ -34,6 +34,36 @@ describe('buildDocumentation', () => {
     ).toMatchSnapshot();
   });
 
+  // waiting for @babel/generator fix deployed and published: https://github.com/babel/babel/pull/10258
+  it.skip('should support class static interface', async function() {
+    const sourceCode = `
+      interface ClockConstructor {
+        new (hour: number, minute: number): any;
+        test(): string;
+      }
+      
+      interface ClockInterface {
+        tick(): any;
+      }
+      
+      const Clock: ClockConstructor = class Clock implements ClockInterface {
+        static test() { return 'string'; }
+        constructor(h: number, m: number) {}
+        tick() {
+            console.log("beep beep");
+        }
+      }
+    `;
+
+    expect(
+      await buildDocumentation({
+        source: sourceCode,
+        tag: 'UI',
+        title: 'Documentation',
+      }),
+    ).toMatchSnapshot();
+  });
+
   it('should build documentation for functions ', async () => {
     const sourceCode = `
       /**

--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -56,6 +56,66 @@ exports[`buildMarkdown for API class should render markdown for getters/setters 
 "
 `;
 
+exports[`buildMarkdown for API class should render markdown for interface with method 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## bar()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>foo</code>
+        </td>
+        <td>
+            <div class=\\"function-type\\">function(): string</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
+exports[`buildMarkdown for API class should render markdown for interface with method as arrow function 1`] = `
+"<!-- Generated automatically. Update this documentation by updating the source code. -->
+
+# API Methods
+
+## bar()
+
+<div class=\\"method-list\\">
+  <table>
+    <thead>
+      <tr>
+        <th class=\\"title\\">RETURN VALUE</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class=\\"param\\">
+          <code>foo</code>
+        </td>
+        <td>
+            <div class=\\"function-type\\">function(): string</div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+"
+`;
+
 exports[`buildMarkdown for API class should render markdown for methods default value 1`] = `
 "<!-- Generated automatically. Update this documentation by updating the source code. -->
 

--- a/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
+++ b/packages/okidoc-md/src/buildMarkdown/__snapshots__/buildMarkdown.spec.js.snap
@@ -139,15 +139,6 @@ myMethod comment
             <p><code>a</code> description</p>
         </td>
       </tr>
-      <tr>
-        <td class=\\"param\\">
-          <code>b</code>
-        </td>
-        <td>
-            <div class=\\"type\\">number?</div>
-            <p><code>b</code> description</p>
-        </td>
-      </tr>
     </tbody>
   </table>
 </div>

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -236,7 +236,9 @@ describe('buildMarkdown', () => {
       expect(markdown).toMatchSnapshot();
     });
 
-    // todo
+    // documentationjs started to generate different Comment structure (without "type" prop)
+    // for methods declared in "foo(): string" notation (parenthesis before ":")
+    // need to either fix this in documentationjs project or adapt within our code
     it.skip('should render markdown for interface with method', async () => {
       const documentationSource = `
         /** */

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -222,16 +222,28 @@ describe('buildMarkdown', () => {
       expect(markdown).toMatchSnapshot();
     });
 
+    // pending resolution: https://github.com/documentationjs/documentation/issues/1267
+    it.skip('should render markdown for interface with optional property', async () => {
+      const documentationSource = `
+     /** MyResult interface */
+      interface MyResult {
+        /** */
+        a?: string;
+      }
+    `;
+      const markdown = await getMarkdown(documentationSource, { title });
+
+      expect(markdown).toMatchSnapshot();
+    });
+
     it('should render markdown for methods interface as return type', async () => {
       const documentationSource = `
      /**
       * MyResult interface
-      * @property a - \`a\` description
-      * @property b - \`b\` description
       */
       interface MyResult {
+        /** @property a - \`a\` description */
         a: string;
-        b?: number;
       }
 
       /** Example class jsdoc */
@@ -295,11 +307,11 @@ describe('buildMarkdown', () => {
       const documentationSource = `
       /**
       * MyFuncResult interface
-      * @property a - \`a\` description
-      * @property b - \`b\` description
       */
       interface MyFuncResult {
+        /** @property a - \`a\` description */
         a: string;
+        /** @property b - \`b\` description */
         b: number;
       }
 
@@ -365,15 +377,16 @@ describe('buildMarkdown', () => {
 
     it('should render valid markdown with function in return type interface', async () => {
       const documentationSource = `
-        /**
-        * @property update - update entity
-        * @property destroy - destroy entity
-        */
+        /** */
         interface MyEntity {
+          /** */
           id: string;
+          /** */
           title: string;
-          updateTitle(id: string, title: string): Promise<any>;
-          destroy(): void;
+          /** */
+          updateTitle: (id: string, title: string) => Promise<any>;
+          /** @property destroy - destroy entity */
+          destroy: () => void;
         }
       
         /**
@@ -410,7 +423,9 @@ describe('buildMarkdown', () => {
       const documentationSource = `
       /** */
       interface IResult {
+        /** */
         x: number;
+        /** */
         y: number;
       }
 
@@ -444,7 +459,9 @@ describe('buildMarkdown', () => {
       const documentationSource = `
       /** */
       interface IResult {
+        /** */
         x: number;
+        /** */
         y: number;
       }
 

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdown.spec.js
@@ -225,12 +225,47 @@ describe('buildMarkdown', () => {
     // pending resolution: https://github.com/documentationjs/documentation/issues/1267
     it.skip('should render markdown for interface with optional property', async () => {
       const documentationSource = `
-     /** MyResult interface */
+      /** MyResult interface */
       interface MyResult {
         /** */
         a?: string;
       }
-    `;
+      `;
+      const markdown = await getMarkdown(documentationSource, { title });
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    // todo
+    it.skip('should render markdown for interface with method', async () => {
+      const documentationSource = `
+        /** */
+        interface MyResult {
+          /** */
+          foo(): string;
+        }
+        
+        /** */
+        function bar(): MyResult {}
+      `;
+
+      const markdown = await getMarkdown(documentationSource, { title });
+
+      expect(markdown).toMatchSnapshot();
+    });
+
+    it('should render markdown for interface with method as arrow function', async () => {
+      const documentationSource = `
+        /** */
+        interface MyResult {
+          /** */
+          foo: () => string;
+        }
+        
+        /** */
+        function bar(): MyResult {}
+      `;
+
       const markdown = await getMarkdown(documentationSource, { title });
 
       expect(markdown).toMatchSnapshot();

--- a/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
+++ b/packages/okidoc-md/src/buildMarkdown/buildMarkdownAST/parseReturnsComment.js
@@ -13,20 +13,22 @@ function getInterfaceByType(type, interfaces) {
   if (type.type === Syntax.NameExpression) {
     return interfaces.find(
       _interface =>
-        _interface.name === type.name && _interface.properties.length > 0,
+        _interface.name === type.name && _interface.members.instance.length > 0,
     );
   }
 }
 
 function getParamsFromInterface(_interface) {
-  return _interface.properties.map(property => {
-    const tag = _interface.tags.find(
-      tag => tag.title === 'property' && tag.name === property.name,
+  return _interface.members.instance.map(member => {
+    const tag = member.tags.find(
+      tag => tag.title === 'property' && tag.name === member.name,
     );
 
     return {
-      ...property,
-      description: tag && parseMarkdown(tag.description),
+      title: 'property',
+      name: member.name,
+      type: member.type,
+      ...(tag && { description: parseMarkdown(tag.description) }),
     };
   });
 }

--- a/packages/okidoc-md/src/utils/parseSource.js
+++ b/packages/okidoc-md/src/utils/parseSource.js
@@ -1,4 +1,4 @@
-import { parse } from 'babylon';
+import { parse } from '@babel/parser';
 import { codeFrameColumns } from '@babel/code-frame';
 
 function parseSource(source) {
@@ -9,7 +9,12 @@ function parseSource(source) {
         'typescript',
         'classProperties',
         'objectRestSpread',
-        'decorators',
+        [
+          'decorators',
+          {
+            decoratorsBeforeExport: true,
+          },
+        ],
       ],
     });
   } catch (error) {

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,6 +1,9 @@
-module.exports = function(wallaby) {
+module.exports = function() {
   return {
     files: [
+      { pattern: './jest.config.js', instrument: false },
+      { pattern: './config/jest/babelTransform.js', instrument: false },
+      { pattern: 'packages/**/.babelrc', instrument: false },
       'packages/**/src/**/*.js',
       'packages/**/src/**/*.ts',
       '!packages/**/node_modules/**',
@@ -13,13 +16,5 @@ module.exports = function(wallaby) {
       runner: 'node',
     },
     testFramework: 'jest',
-    compilers: {
-      '**/*.js': wallaby.compilers.babel(),
-    },
-    setup: function(wallaby) {
-      const jestConfig = require('./package.json').jest;
-
-      wallaby.testFramework.configure(jestConfig);
-    },
   };
 };


### PR DESCRIPTION
Only the last commit is relevant (forked from `gw2207`, will need to rebase after latter will be merged).

Pending for resolution of https://github.com/documentationjs/documentation/issues/1267

Should be thoroughly revised. @bodia-uz
As it turned out, relying on `Comment` entity yielded from `documentation.build()` is risky. It is possible that they changed something else in the `Comment` structure (in addition to emptying `properties` list) without putting it into _MIGRATION_GUIDE_. It is possible that we just don't have enough tests coverage that might potentially reveal other issues with the new structure.

This is Work In Progress PR. Also need to check if we can remove workaround's related to prior usage of flow-parser in old version of documentationjs: https://github.com/wix/okidoc/issues/68